### PR TITLE
task to only deploy files that have changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-shopify",
   "description": "Grunt plug-in for publishing Shopify theme templates and assets.",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "homepage": "https://github.com/wilr/grunt-shopify",
   "author": {
     "name": "Will Rossiter",
@@ -39,7 +39,9 @@
   ],
   "dependencies": {
     "async": "~0.2.9",
+    "growl": "^1.9.2",
     "isbinaryfile": "~2.0.0",
+    "lodash": "^4.16.2",
     "shopify-api": "~0.2.2"
   },
   "devDependencies": {

--- a/tasks/lib/shopify.js
+++ b/tasks/lib/shopify.js
@@ -620,7 +620,7 @@ module.exports = function(grunt) {
                 case 'changed':
                 case 'renamed':
                 shopify.queue.push({
-                    action: 'upload-changed',
+                    action: 'upload',
                     filepath: filepath,
                     done: errorHandler
                 });

--- a/tasks/shopify.js
+++ b/tasks/shopify.js
@@ -47,6 +47,14 @@ module.exports = function(grunt) {
         }
     });
 
+    grunt.registerTask('shopify:upload-changed', 'Uploads changed files to Shopify', function() {
+        var done = this.async();
+        var options = {
+            noJson: grunt.option('no-json')
+        }
+        shopify.deployChanged(done, options);
+    });
+
     grunt.registerTask('shopify:delete', 'Removes a theme file from Shopify', function(p) {
         var done = this.async();
         shopify.remove(p, done);


### PR DESCRIPTION
Seems like it's been killing everyone to re-upload so many files when only a couple change. This modification adds a grunt task `shopify:upload-changed`
